### PR TITLE
Increase cluster node count

### DIFF
--- a/assets/k3d.config.yml
+++ b/assets/k3d.config.yml
@@ -3,7 +3,7 @@ kind: Simple
 metadata:
   name: nextjs-grpc-infra-target-local
 servers: 1
-agents: 2
+agents: 5
 kubeAPI:
   host: local.targets.infra.nextjs-grpc.projects.utkusarioglu.com
   hostIP: "127.0.0.1"
@@ -39,6 +39,15 @@ options:
       - arg: --node-name=worker-1
         nodeFilters:
           - agent:1
+      - arg: --node-name=worker-2
+        nodeFilters:
+          - agent:2
+      - arg: --node-name=worker-3
+        nodeFilters:
+          - agent:3
+      - arg: --node-name=worker-4
+        nodeFilters:
+          - agent:4
     nodeLabels:
       - label: k3d-node=0
         nodeFilters:


### PR DESCRIPTION
Closes #7 by increasing the number of worker nodes to 5. This pr also tags the
nodes as `worker-...`. This is done to have the server and agent names to have
the same number of characters, allowing easier mental parse on cli based lists.
