### PR TITLE
Chore: Add persistent volumes vars

### DIFF
--- a/.docker/docker-compose.ci.yml
+++ b/.docker/docker-compose.ci.yml
@@ -14,5 +14,6 @@ services:
       GITHUB_WORKSPACE: ${GITHUB_WORKSPACE}
       SKIP_STAGES: ${SKIP_STAGES}
       TERRATEST_REPOS: ${TERRATEST_REPOS}
+      PERSISTENT_VOLUMES_ROOT: ${HOME}/volumes
     working_dir: /utkusarioglu-com/projects/nextjs-grpc/infra/targets/local
     entrypoint: scripts/run-tests-entrypoint.sh

--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -8,3 +8,5 @@ services:
       grafana.nextjs-grpc.utkusarioglu.com: host-gateway
       jaeger.nextjs-grpc.utkusarioglu.com: host-gateway
       prometheus.nextjs-grpc.utkusarioglu.com: host-gateway
+    environment:
+      PERSISTENT_VOLUMES_ROOT: ${HOME}/dev/volumes/nextjs-grpc

--- a/assets/k3d.config.yml
+++ b/assets/k3d.config.yml
@@ -15,6 +15,11 @@ ports:
   - port: 443:443
     nodeFilters:
       - loadbalancer
+volumes:
+  - volume: ${PERSISTENT_VOLUMES_ROOT}/ethereum-pv:/persistent-volumes/ethereum-pv
+    nodeFilters:
+      - agent:3
+      - agent:4
 options:
   k3d:
     wait: true

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,12 @@
 module "app_tier_1" {
   source = "../../configs/app/modules/tier-1"
 
-  project_root_path = local.project_root_path
-  helm_timeout_unit = var.helm_timeout_unit
-  helm_atomic       = var.helm_atomic
-  sld               = var.sld
-  tld               = var.tld
+  project_root_path       = local.project_root_path
+  helm_timeout_unit       = var.helm_timeout_unit
+  helm_atomic             = var.helm_atomic
+  sld                     = var.sld
+  tld                     = var.tld
+  persistent_volumes_root = var.persistent_volumes_root
 }
 
 module "ingress" {

--- a/vars.tf
+++ b/vars.tf
@@ -13,3 +13,8 @@ variable "sld" {
 variable "tld" {
   type = string
 }
+
+variable "persistent_volumes_root" {
+  type        = string
+  description = "Root folder for all the persistent volumes attached to nodes"
+}

--- a/vars/main.ci.tfvars
+++ b/vars/main.ci.tfvars
@@ -1,6 +1,2 @@
-project_root_rel_path = "../../.."
-cluster_name          = "nextjs-grpc-infra-target-local"
-helm_timeout_unit     = 600
-helm_atomic           = true
-sld                   = "nextjs-grpc.utkusarioglu"
-tld                   = "com"
+helm_timeout_unit = 600
+helm_atomic       = true

--- a/vars/main.common.tfvars
+++ b/vars/main.common.tfvars
@@ -1,0 +1,7 @@
+project_root_rel_path = "../../.."
+cluster_name          = "nextjs-grpc-infra-target-local"
+sld                   = "nextjs-grpc.utkusarioglu"
+tld                   = "com"
+
+# Has to match k3d config
+persistent_volumes_root = "/persistent-volumes"

--- a/vars/main.dev.tfvars.example
+++ b/vars/main.dev.tfvars.example
@@ -1,6 +1,0 @@
-project_root_rel_path = "../../.."
-cluster_name          = "example"
-helm_timeout_unit     = 0
-helm_atomic           = false
-sld                   = "example"
-tld                   = "example"


### PR DESCRIPTION
- Close #10 by adding  variables and values for controlling where the
  persistent volumes are attached.
- Add a persistent volume for upcoming PostgreSQL deployment. This
  will be the first time this new pipeline will be used.
- Create new vars file for common properties between ci and local.
- Remove obsolete vars example file.
