### PR TITLE
feat/issue/13

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,7 @@ module "ingress" {
   project_root_path = local.project_root_path
   helm_timeout_unit = var.helm_timeout_unit
   helm_atomic       = var.helm_atomic
+  deployment_mode   = var.deployment_mode
 
   depends_on = [
     module.app_tier_1

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,7 @@ module "app_tier_1" {
   sld                     = var.sld
   tld                     = var.tld
   persistent_volumes_root = var.persistent_volumes_root
+  deployment_mode         = var.deployment_mode
 }
 
 module "ingress" {
@@ -31,6 +32,7 @@ module "app_tier_2" {
   environment           = "local"
   cluster_name          = var.cluster_name
   ingress_sg            = "not-needed-in-local"
+  deployment_mode       = var.deployment_mode
 
   depends_on = [
     module.ingress

--- a/modules/ingress/ingress.tf
+++ b/modules/ingress/ingress.tf
@@ -1,5 +1,5 @@
 resource "helm_release" "ingress" {
-  count      = 1
+  count      = local.deployment_configs.ingress.count
   name       = "ingress"
   chart      = "ingress-nginx"
   repository = "https://kubernetes.github.io/ingress-nginx"

--- a/modules/ingress/locals.tf
+++ b/modules/ingress/locals.tf
@@ -1,0 +1,16 @@
+locals {
+  deployment_config_presets = {
+    all = {
+      ingress = {
+        count = 1
+      }
+    }
+    ethereum_storage = {
+      ingress = {
+        count = 1
+      }
+    }
+  }
+
+  deployment_configs = local.deployment_config_presets[var.deployment_mode]
+}

--- a/modules/ingress/vars.tf
+++ b/modules/ingress/vars.tf
@@ -9,3 +9,8 @@ variable "helm_timeout_unit" {
 variable "helm_atomic" {
   type = bool
 }
+
+variable "deployment_mode" {
+  type        = string
+  description = "Specify a mode that determines which resources will be deployed. Example: 'all' deploys everything"
+}

--- a/vars.tf
+++ b/vars.tf
@@ -18,3 +18,8 @@ variable "persistent_volumes_root" {
   type        = string
   description = "Root folder for all the persistent volumes attached to nodes"
 }
+
+variable "deployment_mode" {
+  type        = string
+  description = "Specify a mode that determines which resources will be deployed. Example: 'all' deploys everything"
+}

--- a/vars/main.ci.tfvars
+++ b/vars/main.ci.tfvars
@@ -1,2 +1,3 @@
 helm_timeout_unit = 600
 helm_atomic       = true
+deployment_mode   = "all"


### PR DESCRIPTION
Feat: Add deployment modes
    
- Close #13 by implementing `deployment_mode` and related local values.
  This value is also passed downstream to modules that require it. A
  similar commit has been made in `infra/config/app` to enable
  deployment modes in that repo as well.
