### PR TITLE
Feat: Add mock region support

### DIFF
--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -10,3 +10,4 @@ services:
       prometheus.nextjs-grpc.utkusarioglu.com: host-gateway
     environment:
       PERSISTENT_VOLUMES_ROOT: ${HOME}/dev/volumes/nextjs-grpc
+      CLUSTER_REGION: eu-central-1

--- a/assets/k3d.config.yml
+++ b/assets/k3d.config.yml
@@ -57,12 +57,26 @@ options:
         nodeFilters:
           - agent:4
     nodeLabels:
-      - label: k3d-node=0
+      - label: "topology.kubernetes.io/region=${CLUSTER_REGION}"
+        nodeFilters:
+          - server:*
+          - agent:*
+      - label: vault_in_k8s=true
         nodeFilters:
           - agent:0
-      - label: k3d-node=1
+          - agent:2
+          - agent:4
+      - label: "topology.kubernetes.io/zone=${CLUSTER_REGION}a"
         nodeFilters:
+          - agent:0
           - agent:1
+      - label: "topology.kubernetes.io/zone=${CLUSTER_REGION}b"
+        nodeFilters:
+          - agent:2
+      - label: "topology.kubernetes.io/zone=${CLUSTER_REGION}c"
+        nodeFilters:
+          - agent:3
+          - agent:4
   kubeconfig:
     updateDefaultKubeconfig: true
     switchCurrentContext: true


### PR DESCRIPTION
- Closes #15 by adding node labels that establish mock zones in a
  region. These can be used for setting up affinity rules.
- Add `CLUSTER_REGION` environment variable for use by k3d.
