### PR TITLE
Test: Fail CI tests according to exit codes

### DIFF
--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -4,8 +4,6 @@ services:
   nextjs-grpc-infra-target-local:
     environment:
       PERSISTENT_VOLUMES_ROOT: ${HOME}/dev/volumes/nextjs-grpc
-      TARGET_VOLUMES_ROOT: /var/lib/rancher/k3s/storage
-      CLUSTER_REGION: eu-central-1
     extra_hosts:
       local.targets.infra.nextjs-grpc.projects.utkusarioglu.com: host-gateway
       nextjs-grpc.utkusarioglu.com: host-gateway

--- a/scripts/run-tests-entrypoint.sh
+++ b/scripts/run-tests-entrypoint.sh
@@ -4,7 +4,7 @@
 # This file acts as the entrypoint for docker compose run that handles
 # CI tests
 #
-
+exit_codes=0
 k3d_config_file_path=$1
 if [ -z "$k3d_config_file_path" ]; then
   echo "Error: No path was given for K3d config"
@@ -16,12 +16,26 @@ HOME=/home/terraform
 
 echo "Running devcontainer postCreateCommand…"
 scripts/post-create-command.sh
+step_exit_code=$?
+((exit_codes+=$step_exit_code))
+echo "'scripts/post-create-command.sh' finalized with exit code $step_exit_code"
 
 echo "Creating cluster using: '$k3d_config_file_path'…"
 k3d cluster create -c $k3d_config_file_path
+step_exit_code=$?
+((exit_codes+=$step_exit_code))
+echo "Cluster creation finalized with exit code $step_exit_code"
 
 echo "Starting tests…"
 scripts/run-tests.sh 
+step_exit_code=$?
+((exit_codes+=$step_exit_code))
+echo "'scripts/run-tests.sh' finalized with exit code $step_exit_code"
 
 echo "Deleting cluster using: '$k3d_config_file_path'…"
 k3d cluster delete -c $k3d_config_file_path
+step_exit_code=$?
+((exit_codes+=$step_exit_code))
+echo "Cluster deletion finalized with exit code $step_exit_code"
+
+exit $exit_codes

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -15,14 +15,28 @@ if [ ! -z "$SKIP_STAGES" ]; then
   done
 fi
 
+exit_codes=0
+
 for terratest_repo in $TERRATEST_REPOS; do
+  if [ $exit_codes -gt 0 ]; then
+    echo "Error: Skipping '$terratest_repo' tests due to previous failures"
+    continue 
+  fi
   echo "Running \`$terratest_repo\` tests…"
   cd $BASEPATH/$terratest_repo/tests 
   bash -c "ENVIRONMENT=$ENVIRONMENT $skip_env_vars SKIP_teardown=1 go test -timeout 90m"
+  step_exit_code=$?
+  ((exit_codes+=$step_exit_code))
+  echo "'$terratest_repo' finalized with exit code $step_exit_code"
 done
 
 if [ "$ENVIRONMENT" != "ci" ] && [[ $skip_stages != *"teardown"* ]]; then
   echo "Running \`infra/targets/local\` teardown…"
   cd $current_dir/tests
   ENVIRONMENT=$ENVIRONMENT SKIP_setup=1 SKIP_http_local=1 go test -timeout 90m 
+  step_exit_code=$?
+  ((exit_codes+=$step_exit_code))
+  echo "Teardown finalized with exit code $step_exit_code"
 fi
+
+exit $exit_codes


### PR DESCRIPTION
- Set up CI tests so that failing runs actually return their exit codes.
  Tests steps were prevented from returning their exit codes as the bash
  files running the tests didn't collect them. This commit ensures that
  every step's exit code is collected.
- Move some enviroment variables in docker compose files from `dev` to
  `common` as these values are common to all environments.
