### PR TITLE
Feat: CA creator step for CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -130,6 +130,11 @@ jobs:
           E2E_VIEWPORT_SIZES=${{ env.E2E_VIEWPORT_SIZES }}
           BASE_URL=${{ env.BASE_URL }}
           EOF
+      
+      - name: Create CA
+        working-directory: infra/targets/local
+        run: |
+          scripts/openssl-create-ca.sh
 
       - name: Run Tests
         working-directory: infra/targets/local

--- a/scripts/openssl-create-ca.sh
+++ b/scripts/openssl-create-ca.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+ca_path=".certs/ca"
+key_path="$ca_path/ca.key"
+cert_path="$ca_path/ca.crt"
+
+mkdir -p "$ca_path"
+
+openssl req -x509 -nodes -days 1 \
+  -newkey ec:<(openssl ecparam -name prime256v1) \
+  -subj "/C=UT/ST=UT/L=UT/O=utkusarioglu" \
+  -keyout "$key_path" \
+  -out "$cert_path"
+
+openssl ec -in "$key_path" -text -noout
+openssl x509 -in "$cert_path" -text -noout


### PR DESCRIPTION
- Close #26 by creating a CA creation step in CI. This step creates the
  CA that will be used by terrafrom to create ingress server cert.
- Create `scripts/openssl-ca-create.sh` for the OpenSSL commands that are used
  for creating the CA.
